### PR TITLE
Refine build scripts for iOS static libraries

### DIFF
--- a/tools/build-curl4ios.sh
+++ b/tools/build-curl4ios.sh
@@ -26,13 +26,13 @@ pwd_path="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
  
 # Setup architectures, library name and other vars + cleanup from previous runs
-ARCHS=("arm64" "armv7s" "armv7" "i386" "x86_64")
-SDKS=("iphoneos" "iphoneos" "iphoneos" "iphonesimulator" "iphonesimulator")
-PLATFORMS=("iPhoneOS" "iPhoneOS" "iPhoneOS" "iPhoneSimulator" "iPhoneSimulator")
+ARCHS=("arm64" "armv7" "i386" "x86_64")
+SDKS=("iphoneos" "iphoneos" "iphonesimulator" "iphonesimulator")
+PLATFORMS=("iPhoneOS" "iPhoneOS" "iPhoneSimulator" "iPhoneSimulator")
 LIB_NAME="curl-7.51.0"
 DEVELOPER=`xcode-select -print-path`
 TOOLCHAIN=/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain
-SDK_VERSION=""10.2""
+SDK_VERSION="10.2"
 IPHONEOS_DEPLOYMENT_TARGET="6.0"
 LIB_DEST_DIR="${pwd_path}/../output/ios/curl-ios-universal"
 HEADER_DEST_DIR="include"

--- a/tools/build-protobuf4ios.sh
+++ b/tools/build-protobuf4ios.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+
+## Environments
+
+# Exit the build pass if any command returns a non-zero value
+#set -o errexit
+
+# Echo commands
+set -x
+
+# 13.4.0 - Mavericks
+# 14.0.0 - Yosemite
+# 15.0.0 - El Capitan
+# 16.0.0 - Sierra
+DARWIN=darwin`uname -r`
+
+MIN_SDK_VERSION=8.0
+
+IPHONEOS_SYSROOT=`xcrun --sdk iphoneos --show-sdk-path`
+IPHONESIMULATOR_SYSROOT=`xcrun --sdk iphonesimulator --show-sdk-path`
+
+# Verbose clang output
+#CLANG_VERBOSE="--verbose"
+
+CC=clang
+CXX=clang
+
+SILENCED_WARNINGS="-Wno-unused-local-typedef -Wno-unused-function"
+
+# NOTE: Google Protobuf does not currently build if you specify 'libstdc++'
+# instead of `libc++` here.
+STDLIB=libc++
+
+CFLAGS="${CLANG_VERBOSE} ${SILENCED_WARNINGS} -DNDEBUG -g -O0 -pipe -fPIC -fcxx-exceptions"
+CXXFLAGS="${CFLAGS} -std=c++11 -stdlib=${STDLIB}"
+
+LDFLAGS="-stdlib=${STDLIB}"
+LIBS="-lc++ -lc++abi"
+
+PROTOC=`which protoc`
+
+PREFIX=`pwd`/out
+if [ -d ${PREFIX} ]
+then
+    rm -rf "${PREFIX}"
+fi
+mkdir -p "${PREFIX}/platform"
+
+## Functions
+
+build-arch() {
+  HOST=$1
+  ARCH=$2
+  PLATFORM_NAME=${ARCH}
+  SYSROOT=${IPHONEOS_SYSROOT}
+
+  make distclean
+  ./configure \
+    --build=x86_64-apple-${DARWIN} \
+    --host=${HOST} \
+    --with-protoc=${PROTOC} \
+    --disable-shared \
+    --prefix=${PREFIX} \
+    --exec-prefix=${PREFIX}/platform/${PLATFORM_NAME} \
+    "CC=${CC}" \
+    "CFLAGS=${CFLAGS} -miphoneos-version-min=${MIN_SDK_VERSION} -arch ${ARCH} -isysroot ${SYSROOT}" \
+    "CXX=${CXX}" \
+    "CXXFLAGS=${CXXFLAGS} -miphoneos-version-min=${MIN_SDK_VERSION} -arch ${ARCH} -isysroot ${SYSROOT}" \
+    LDFLAGS="-arch ${ARCH} -miphoneos-version-min=${MIN_SDK_VERSION} ${LDFLAGS}" \
+    "LIBS=${LIBS}"
+
+  make -j8
+  make install
+}
+
+build-i386-simulator() {
+  ARCH=i386
+  HOST=${ARCH}-apple-${DARWIN}
+  PLATFORM_NAME=${ARCH}-simulator
+  SYSROOT=${IPHONESIMULATOR_SYSROOT}
+
+  make distclean
+  ./configure \
+    --build=x86_64-apple-${DARWIN} \
+    --host=${HOST} \
+    --with-protoc=${PROTOC} \
+    --disable-shared \
+    --prefix=${PREFIX} \
+    --exec-prefix=${PREFIX}/platform/${PLATFORM_NAME} \
+    "CC=${CC}" \
+    "CFLAGS=${CFLAGS} -mios-simulator-version-min=${MIN_SDK_VERSION} -arch ${ARCH} -isysroot ${SYSROOT}" \
+    "CXX=${CXX}" \
+    "CXXFLAGS=${CXXFLAGS} -mios-simulator-version-min=${MIN_SDK_VERSION} -arch ${ARCH} -isysroot ${SYSROOT}" \
+    LDFLAGS="-arch ${ARCH} -mios-simulator-version-min=${MIN_SDK_VERSION} ${LDFLAGS}" \
+    "LIBS=${LIBS}"
+
+  make -j8
+  make install
+}
+
+build-x86_64-simulator() {
+  ARCH=x86_64
+  PLATFORM_NAME=${ARCH}-simulator
+  SYSROOT=${IPHONESIMULATOR_SYSROOT}
+
+  make distclean
+  ./configure --prefix=${PREFIX} \
+              --exec-prefix=${PREFIX}/platform/${PLATFORM_NAME} \
+              --with-sysroot=${SYSROOT} \
+              --with-protoc=`which protoc` \
+              --enable-static \
+              --disable-shared
+
+  make -j8
+  make install
+}
+
+build-fat-lib() {
+  OUT=${PREFIX}/universal
+  mkdir -p ${OUT}
+
+  PLATFORM_ROOT=${PREFIX}/platform
+  LIB_LITE=libprotobuf-lite.a
+  LIPO=lipo
+
+  ${LIPO} ${PLATFORM_ROOT}/arm64/lib/${LIB_LITE} \
+          ${PLATFORM_ROOT}/armv7/lib/${LIB_LITE} \
+          ${PLATFORM_ROOT}/x86_64-simulator/lib/${LIB_LITE} \
+          ${PLATFORM_ROOT}/i386-simulator/lib/${LIB_LITE} \
+          -create \
+          -output ${OUT}/${LIB_LITE}
+}
+
+## Build pass
+
+./autogen.sh
+
+build-x86_64-simulator
+build-i386-simulator
+
+build-arch arm arm64
+build-arch armv7-apple-${DARWIN} armv7
+
+build-fat-lib
+
+echo DONE!

--- a/tools/build-protobuf4ios.sh
+++ b/tools/build-protobuf4ios.sh
@@ -39,7 +39,9 @@ LIBS="-lc++ -lc++abi"
 
 PROTOC=`which protoc`
 
-PREFIX=`pwd`/out
+PROTOBUF_SOURCE_DIR=protobuf
+
+PREFIX=`pwd`/../output/protobuf
 if [ -d ${PREFIX} ]
 then
     rm -rf "${PREFIX}"
@@ -120,9 +122,17 @@ build-fat-lib() {
   mkdir -p ${OUT}
 
   PLATFORM_ROOT=${PREFIX}/platform
-  LIB_LITE=libprotobuf-lite.a
   LIPO=lipo
 
+  LIB=libprotobuf.a
+  ${LIPO} ${PLATFORM_ROOT}/arm64/lib/${LIB} \
+          ${PLATFORM_ROOT}/armv7/lib/${LIB} \
+          ${PLATFORM_ROOT}/x86_64-simulator/lib/${LIB} \
+          ${PLATFORM_ROOT}/i386-simulator/lib/${LIB} \
+          -create \
+          -output ${OUT}/${LIB}
+
+  LIB_LITE=libprotobuf-lite.a
   ${LIPO} ${PLATFORM_ROOT}/arm64/lib/${LIB_LITE} \
           ${PLATFORM_ROOT}/armv7/lib/${LIB_LITE} \
           ${PLATFORM_ROOT}/x86_64-simulator/lib/${LIB_LITE} \
@@ -132,6 +142,8 @@ build-fat-lib() {
 }
 
 ## Build pass
+
+cd ${PROTOBUF_SOURCE_DIR}
 
 ./autogen.sh
 


### PR DESCRIPTION
- Modified the `libcurl` build script to remove `armv7s`
- Added the `libprotobuf-lite` build script